### PR TITLE
Turn on statesave for candidate urls table

### DIFF
--- a/sde_indexing_helper/static/js/candidate_url_list.js
+++ b/sde_indexing_helper/static/js/candidate_url_list.js
@@ -20,6 +20,7 @@ function initializeDataTable() {
     var candidate_urls_table = $('#candidate_urls_table').DataTable({
         "scrollY": true,
         "serverSide": true,
+        "stateSave": true,
         "ajax": {
             "url": `/api/candidate-urls/?format=datatables&collection_id=${collection_id}`,
             "data": function (d) {


### PR DESCRIPTION
On refreshing it stays on the page you were last on.