### PR TITLE
8-item-selected-tabs: move table into metadata tab, set up placeholde…

### DIFF
--- a/sde_indexing_helper/static/css/collection_detail.css
+++ b/sde_indexing_helper/static/css/collection_detail.css
@@ -36,3 +36,36 @@
 .comment p {
     margin-top: 5px;
 }
+
+/* nav tab headers, renamed to prevent material dashboard css conflict */
+.tab-nav {
+    color: black;
+    padding-right: 25px;
+    padding-left: 25px;
+    font-weight: 500;
+}
+
+/* tab headers hover effect */
+.tab-nav:hover {
+    text-decoration: underline;
+    color: #0066CA; 
+}
+
+/* alligning tab container with the table  */
+.nav-tabs {
+    padding-left: 0px;
+}
+
+/* active tab  */
+.nav-item > .active {
+    color: #0066CA;
+    font-weight: 700;
+    border-bottom: 2px solid #FF3D57;
+    padding-bottom: 30px;
+}
+
+/* line under the tab options */
+div > .nav {
+    padding-bottom: 30px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.3);
+}

--- a/sde_indexing_helper/templates/sde_collections/collection_detail.html
+++ b/sde_indexing_helper/templates/sde_collections/collection_detail.html
@@ -7,6 +7,7 @@
     {{ block.super }}
     <link rel="stylesheet" href="{% static 'css/collection_detail.css' %}">
 {% endblock stylesheets %}
+
 {% block content %}
     <br>
     <div class="row">
@@ -19,136 +20,159 @@
             <a href="{{ collection.server_url_secret_prod }}" target="_blank" style="color:white"><button class="btn btn-primary btn-sm pull-right">View on secret prod</button></a>
         </div>
     </div>
-    <table class="table table-striped">
-        <tbody>
-            <tr>
-                <th>URL</th>
-                <td>
-                    <a target="_blank"
-                       href=" {% if collection.url %}{{ collection.url }}{% endif %} ">{{ collection.url }}</a>
-                </td>
-            </tr>
-            <tr>
-                <th>Config Folder</th>
-                <td>{{ collection.config_folder }}</td>
-            </tr>
-            <tr>
-                <th>Division</th>
-                <td>{{ collection.get_division_display }}</td>
-            </tr>
-            <tr>
-                <th>Update Frequency</th>
-                <td>{{ collection.get_update_frequency_display }}</td>
-            </tr>
-            <tr>
-                <th>Document Type</th>
-                <td>{{ collection.get_document_type_display }}</td>
-            </tr>
-            <tr>
-                <th>Tree Root</th>
-                <td>{{ collection.tree_root }}</td>
-            </tr>
-            <tr>
-                <th>Notes</th>
-                <td>{{ collection.notes }}</td>
-            </tr>
-            <tr>
-                <th>Sinequa Configuration</th>
-                <td>
-                    <a href="{{ collection.sinequa_configuration }}" target="_blank">{{ collection.sinequa_configuration }}</a>
-                </td>
-            </tr>
-            <tr>
-                <th>GitHub Issue Link</th>
-                <td>
-                    {% if github_form.errors %}
-                        <span class="error-message" id="github-link-error">{{ github_form.errors.github_issue_link }}</span>
-                    {% endif %}
-                    <a id="github-link-display"
-                       href="{{ collection.github_issue_link }}"
-                       target="_blank">{{ collection.github_issue_link }}</a>
-                    <form id="github-link-form"
-                          action="{% url 'sde_collections:detail' collection.pk %}"
-                          method="POST">
-                        {% csrf_token %}
-                        {{ github_form.github_issue_link }}
-                        <button type="submit" class="btn btn-sm btn-primary">Save</button>
-                    </form>
-                    <button type="submit"
-                            class="btn btn-info btn-sm"
-                            id="edit-github-link-button">
-                        <i class="material-icons">edit</i>
-                    </button>
-                    <button type="submit"
-                            class="btn btn-danger btn-sm"
-                            id="cancel-github-link-button">
-                        <i class="material-icons">cancel</i>
-                    </button>
-                </td>
-            </tr>
-            <tr>
-                <th>Candidate URLs</th>
-                <td>
-                    <a href="{% url 'sde_collections:candidate_urls' collection.id %}">View</a>
-                </td>
-            </tr>
-            <tr>
-                <th>Required URLs</th>
-                <td>
-                    {% for required_url in required_urls %}
-                        <form action="{% url 'sde_collections:delete_required_url' required_url.pk %}">
-                            {% csrf_token %}
-                            <button type="submit" class="btn btn-sm btn-danger delete_required_url pull-left" data-id={{ required_url.pk }}>
-                                <i class="material-icons">delete</i>
-                            </button>
-                        </form>
-                        <a href="{{ required_url.url }}">&nbsp;{{ required_url.url }}</a>
-                    {% empty %}
-                        <p>No required URLs yet</p>
-                    {% endfor %}
-                    <form method="post"
-                          action="{% url 'sde_collections:detail' collection.pk %}">
-                        {% csrf_token %}
-                        {{ form.url }}
-                        <button type="submit" class="btn btn-sm btn-primary">Add URL</button>
-                    </form>
-                </td>
-            </tr>
-            <tr>
-                <th>Comments</th>
-                <td>
-                    <div id="comments-display">
-                        {% for comment in comments %}
-                            <div class="comment">
-                                <strong>{{ comment.user.username }}</strong>
-                                <span>{{ comment.created_at|date:"M. d, Y, P" }}</span>
-                                <p>{{ comment.text }}</p>
-                            </div>
-                        {% empty %}
-                            <p>No comments yet</p>
-                        {% endfor %}
-                    </div>
-                </td>
-            </tr>
-            <tr>
-                <th>Post a Comment</th>
-                <td>
-                    <div id="comment-form-container">
-                        {% if user.is_authenticated %}
-                            <form method="post" action="{% url 'sde_collections:detail' collection.pk %}">
+
+    <div>
+
+        <!-- Nav tabs -->
+        <ul class="nav nav-tabs">
+        <li class="nav-item">
+          <a class="tab-nav active" data-toggle="tab" href="#metadata">Metadata</a>
+        </li>
+        <li class="nav-item">
+          <a class="tab-nav" data-toggle="tab" href="#statustimeline">Status Timeline</a>
+        </li>
+        </ul>
+    
+        <!-- Tab panes -->
+        <div class="tab-content">
+        <div class="tab-pane active" id="metadata">
+            <table class="table table-striped">
+                <tbody>
+                    <tr>
+                        <th>URL</th>
+                        <td>
+                            <a target="_blank"
+                               href=" {% if collection.url %}{{ collection.url }}{% endif %} ">{{ collection.url }}</a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Config Folder</th>
+                        <td>{{ collection.config_folder }}</td>
+                    </tr>
+                    <tr>
+                        <th>Division</th>
+                        <td>{{ collection.get_division_display }}</td>
+                    </tr>
+                    <tr>
+                        <th>Update Frequency</th>
+                        <td>{{ collection.get_update_frequency_display }}</td>
+                    </tr>
+                    <tr>
+                        <th>Document Type</th>
+                        <td>{{ collection.get_document_type_display }}</td>
+                    </tr>
+                    <tr>
+                        <th>Tree Root</th>
+                        <td>{{ collection.tree_root }}</td>
+                    </tr>
+                    <tr>
+                        <th>Notes</th>
+                        <td>{{ collection.notes }}</td>
+                    </tr>
+                    <tr>
+                        <th>Sinequa Configuration</th>
+                        <td>
+                            <a href="{{ collection.sinequa_configuration }}" target="_blank">{{ collection.sinequa_configuration }}</a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>GitHub Issue Link</th>
+                        <td>
+                            {% if github_form.errors %}
+                                <span class="error-message" id="github-link-error">{{ github_form.errors.github_issue_link }}</span>
+                            {% endif %}
+                            <a id="github-link-display"
+                               href="{{ collection.github_issue_link }}"
+                               target="_blank">{{ collection.github_issue_link }}</a>
+                            <form id="github-link-form"
+                                  action="{% url 'sde_collections:detail' collection.pk %}"
+                                  method="POST">
                                 {% csrf_token %}
-                                <textarea name="text" class="form-control">{{ comment_form.text.value }}</textarea>
-                                <button type="submit" name="comment_button" class="btn btn-primary">Submit</button>
+                                {{ github_form.github_issue_link }}
+                                <button type="submit" class="btn btn-sm btn-primary">Save</button>
                             </form>
-                        {% else %}
-                            <p>Please log in to post comments.</p>
-                        {% endif %}
-                    </div>
-                </td>
-            </tr>
-        </tbody>
-    </table>
-{% endblock content %}
+                            <button type="submit"
+                                    class="btn btn-info btn-sm"
+                                    id="edit-github-link-button">
+                                <i class="material-icons">edit</i>
+                            </button>
+                            <button type="submit"
+                                    class="btn btn-danger btn-sm"
+                                    id="cancel-github-link-button">
+                                <i class="material-icons">cancel</i>
+                            </button>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Candidate URLs</th>
+                        <td>
+                            <a href="{% url 'sde_collections:candidate_urls' collection.id %}">View</a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Required URLs</th>
+                        <td>
+                            {% for required_url in required_urls %}
+                                <form action="{% url 'sde_collections:delete_required_url' required_url.pk %}">
+                                    {% csrf_token %}
+                                    <button type="submit" class="btn btn-sm btn-danger delete_required_url pull-left" data-id={{ required_url.pk }}>
+                                        <i class="material-icons">delete</i>
+                                    </button>
+                                </form>
+                                <a href="{{ required_url.url }}">&nbsp;{{ required_url.url }}</a>
+                            {% empty %}
+                                <p>No required URLs yet</p>
+                            {% endfor %}
+                            <form method="post"
+                                  action="{% url 'sde_collections:detail' collection.pk %}">
+                                {% csrf_token %}
+                                {{ form.url }}
+                                <button type="submit" class="btn btn-sm btn-primary">Add URL</button>
+                            </form>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Comments</th>
+                        <td>
+                            <div id="comments-display">
+                                {% for comment in comments %}
+                                    <div class="comment">
+                                        <strong>{{ comment.user.username }}</strong>
+                                        <span>{{ comment.created_at|date:"M. d, Y, P" }}</span>
+                                        <p>{{ comment.text }}</p>
+                                    </div>
+                                {% empty %}
+                                    <p>No comments yet</p>
+                                {% endfor %}
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Post a Comment</th>
+                        <td>
+                            <div id="comment-form-container">
+                                {% if user.is_authenticated %}
+                                    <form method="post" action="{% url 'sde_collections:detail' collection.pk %}">
+                                        {% csrf_token %}
+                                        <textarea name="text" class="form-control">{{ comment_form.text.value }}</textarea>
+                                        <button type="submit" name="comment_button" class="btn btn-primary">Submit</button>
+                                    </form>
+                                {% else %}
+                                    <p>Please log in to post comments.</p>
+                                {% endif %}
+                            </div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        
+        </div>
+        <div class="tab-pane fade" id="statustimeline">PLACEHOLDER 2</div>
+        </div>
+      </div>
+
+    {% endblock content %}
 {% block javascripts %}
     <script src="{% static 'js/collection_detail.js' %}"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
 {% endblock javascripts %}


### PR DESCRIPTION
Closes NASA-IMPACT/sde-indexing-helper-frontend#8 

- Add tab for the metadata table
- placeholder for the status timeline tab

When data table is added to other tab, if the table header allignment is not calculating properly between tabs, look to copy the added jquery function that uses `.adjust()` that is in `candidate_url_list.js` (near top)