### PR TITLE
38 counts always visible

### DIFF
--- a/sde_indexing_helper/static/css/collections_list.css
+++ b/sde_indexing_helper/static/css/collections_list.css
@@ -31,6 +31,15 @@ body {
     box-shadow: none;
 }
 
+.dtsp-nameCont .badge{
+    position:absolute;
+    float:left;
+}
+
+.dtsp-name { 
+    margin-left:40px;
+}
+
 .dtsp-countButton{
     opacity:0.6;
     background-color: transparent;


### PR DESCRIPTION
Now the searchPane counts are on the left so they will never be hidden by long text