### PR TITLE
61: searchpane styling in collapse mode and styling collapse buttons

### DIFF
--- a/sde_indexing_helper/static/css/collections_list.css
+++ b/sde_indexing_helper/static/css/collections_list.css
@@ -67,11 +67,6 @@ body {
     border:none !important;
     box-shadow: none;
 }
-/* 
-.dtsp-searchIcon:disabled{
-  background-color: transparent;
-
-} */
 
 .dtsp-caret{
     color: #A7BACD;


### PR DESCRIPTION
Now there isnt white space shown when the search panes are collapsed.