### PR TITLE
62 candidate notification

### DIFF
--- a/sde_indexing_helper/static/js/candidate_url_list.js
+++ b/sde_indexing_helper/static/js/candidate_url_list.js
@@ -876,13 +876,12 @@ function postDocumentTypePatterns(
 }
 
 function postExcludePatterns(match_pattern, match_pattern_type = 0, force) {
-  console.log(match_pattern);
   if (!match_pattern) {
     toastr.error("Please highlight a pattern to exclude.");
     return;
   }
   if(!force){ //If the user clicked the icon in the table, we make the change regardless
-  // if pattern exists in table already
+  // if pattern exists in table already (unless another pattern overrules it)
   var table = $("#exclude_patterns_table").DataTable();
   var itemIdColumnData = table.column(0).data().toArray();
   if (itemIdColumnData.includes(match_pattern)) {


### PR DESCRIPTION
Now notifications on the candidate url tabs only show up when items are added from the first tab of the page.

Also added the "new" text to each bubble

Also fixed a bug where you couldn't click an excluded green check to "include it".  Note that sometimes this still doesn't work if there is another pattern excluding the item.  I made sure to mimick what dev allows. 