### PR TITLE
96 url hover

### DIFF
--- a/sde_indexing_helper/static/css/candidate_url_list.css
+++ b/sde_indexing_helper/static/css/candidate_url_list.css
@@ -207,21 +207,14 @@ letter-spacing: -0.02em;
 }
 
 .sorting_1 {
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
+    overflow: visible;
+    white-space: normal;
+    word-wrap: break-word;
     max-width: 600px;
     width: 600px;
     color: #65B1EF;
   }
-
- .sorting_1:hover {
-    overflow: visible;
-    white-space: normal;
-    word-wrap: break-word;
-    z-index: 1;
- }
-
+  
 .title-dropdown {
     width: fit-content !important;
 }


### PR DESCRIPTION
Remove URL hover effect on Candidate URL page to make highlighting easier.

Closes NASA-IMPACT/sde-indexing-helper-frontend#96