### PR TITLE
68: moving workflow dropdown to the right side of candidate url page

### DIFF
--- a/sde_indexing_helper/static/css/candidate_url_list.css
+++ b/sde_indexing_helper/static/css/candidate_url_list.css
@@ -224,6 +224,8 @@ letter-spacing: -0.02em;
 
 .title-dropdown {
     width: fit-content !important;
+    margin-top:20px;
+    margin-bottom:20px;
 }
 .table tbody tr:nth-child(odd) {
     background-color: #050E19 !important;
@@ -278,4 +280,9 @@ letter-spacing: -0.02em;
    div.dt-container div.dt-info {
     padding-top: 0;
     white-space: normal;
+}
+
+.headerDiv{
+    display: flex;
+    justify-content: space-between;
 }

--- a/sde_indexing_helper/templates/sde_collections/candidate_urls_list.html
+++ b/sde_indexing_helper/templates/sde_collections/candidate_urls_list.html
@@ -24,29 +24,30 @@
 
 {% block content %}
 {% csrf_token %}
+<div class="headerDiv">
 <h1 class="pageTitle">Candidate URLs</h1>
+<button class="btn badge {{ collection.workflow_status_button_color }} dropdown-toggle title-dropdown btn-sm"
+type="button"
+data-toggle="dropdown"
+aria-haspopup="true"
+id="workflow-status-button-{{ collection.id }}"
+aria-expanded="false">{{ collection.get_workflow_status_display }}</button>
+<div class="dropdown-menu"
+aria-labelledby="workflow-status-button-{{ collection.id }}">
+{% for choice in workflow_status_choices %}
+<a class="dropdown-item workflow_status_select" value="{{ choice }}" data-collection-id={{ collection.id }} >{{ choice.label }}</a>
+{% endfor %}
+</div>
+</div>
 <div class="candidateUrlContainer">
 <h3 class="whiteText candidateTitle">
     {{ candidate_urls.count|intcomma }} Candidate URLs for <a
         href="{% url 'sde_collections:detail' collection.pk %}"><strong class="urlStyle underline">{{ collection.name }}</strong></a>
-        <button class="btn badge {{ collection.workflow_status_button_color }} dropdown-toggle title-dropdown btn-sm"
-        type="button"
-        data-toggle="dropdown"
-        aria-haspopup="true"
-        id="workflow-status-button-{{ collection.id }}"
-        aria-expanded="false">{{ collection.get_workflow_status_display }}</button>
-        <div class="dropdown-menu"
-        aria-labelledby="workflow-status-button-{{ collection.id }}">
-        {% for choice in workflow_status_choices %}
-        <a class="dropdown-item workflow_status_select" value="{{ choice }}" data-collection-id={{ collection.id }} >{{ choice.label }}</a>
-        {% endfor %}
-    </div>
     <br>
     <!-- <small class="muted">Base URL: <a href="{{ collection.url }}" target="_blank">{{ collection.url }}</a></small> -->
 </h3>
 
 <div>
-
     <!-- Nav tabs -->
     <ul class="nav nav-tabs">
         <li class="nav-item">


### PR DESCRIPTION
Moved the workflow status out of the candidate url container and across from the title on the right side of the page.