### PR TITLE
64-remove-search: change dom property in datatables

### DIFF
--- a/sde_indexing_helper/static/js/collection_list.js
+++ b/sde_indexing_helper/static/js/collection_list.js
@@ -70,7 +70,7 @@ let table = $("#collection_table").DataTable({
   layout: {
     topStart: "searchPanes",
   },
-  dom: "PiBf",
+  dom: "PiB",
   buttons: [
     {
       text: "Customize Columns",
@@ -85,8 +85,7 @@ let table = $("#collection_table").DataTable({
       targets: 8,
       visible: false,
     },
-    { width: "200px", targets: 1 },
-    {
+    { width: "200px", targets: 1 },    {
       searchPanes: {
         options: [
           {


### PR DESCRIPTION
Closes NASA-IMPACT/sde-indexing-helper-frontend#64

Hide search from DOM in data tables (Do not disable search option, will break our custom search)