### PR TITLE
85 pattern error

### DIFF
--- a/sde_indexing_helper/static/js/candidate_url_list.js
+++ b/sde_indexing_helper/static/js/candidate_url_list.js
@@ -856,7 +856,7 @@ function postDocumentTypePatterns(
     error: function (xhr, status, error) {
       var errorMessage = xhr.responseText;
       if (errorMessage == '{"error":{"non_field_errors":["The fields collection, match_pattern must make a unique set."]},"status_code":400}') {
-        toastr.error("Pattern already exists");
+        toastr.success("Pattern already exists");
         return;
       }
       toastr.error(errorMessage);
@@ -984,7 +984,7 @@ function postTitlePatterns(
     error: function (xhr, status, error) {
       var errorMessage = xhr.responseText;
       if (errorMessage == '{"error":{"non_field_errors":["The fields collection, match_pattern must make a unique set."]},"status_code":400}') {
-        toastr.error("Pattern already exists");
+        toastr.success("Pattern already exists");
         return;
       }
       toastr.error(errorMessage);


### PR DESCRIPTION
Closes NASA-IMPACT/sde-indexing-helper-frontend#85

Change the error from duplicate patterns to a toastr success "Pattern already exists" like the other existing pattern messages.

Can test by adding a title or document pattern with an already existing match pattern.