### PR TITLE
113-dtsp-scroll: fix candidate URL footer bug

### DIFF
--- a/sde_indexing_helper/static/css/project.css
+++ b/sde_indexing_helper/static/css/project.css
@@ -193,7 +193,7 @@ body {
   height:100% !important;
 }
 
-#DataTables_Table_3_wrapper > .justify-content-md-center {
+.dtsp-searchPane .justify-content-md-center {
   height: 198px !important;
 }
 


### PR DESCRIPTION
Make styling only target the relevant table