### PR TITLE
121-dropdown-z-index: increase zindex

### DIFF
--- a/sde_indexing_helper/static/css/collections_list.css
+++ b/sde_indexing_helper/static/css/collections_list.css
@@ -18,10 +18,6 @@ body {
     width: 100%;
 }
 
-.dropdown-menu {
-  z-index: 1030;
-}
-
 .dtsp-nameButton{
     opacity:0.6;
     background-color: transparent !important;

--- a/sde_indexing_helper/static/css/project.css
+++ b/sde_indexing_helper/static/css/project.css
@@ -571,5 +571,8 @@ height: 38px;
     justify-content: center;
 }
 
+.dropdown-menu {
+  z-index: 1030;
+}
 
 


### PR DESCRIPTION
Closes https://github.com/NASA-IMPACT/sde-indexing-helper-frontend/issues/121

Increase zindex to be 1 higher than the header so the dropdown is clickable when pushing to the top.