### PR TITLE
137-font-weight

### DIFF
--- a/sde_indexing_helper/static/css/project.css
+++ b/sde_indexing_helper/static/css/project.css
@@ -211,6 +211,7 @@ body {
 
 .urlStyle{
   color:#65B1EF !important;
+  font-weight:500;
  }
 
  .underline{


### PR DESCRIPTION
Closes https://github.com/NASA-IMPACT/sde-indexing-helper-frontend/issues/137


Font weight increased to 500 for light blue URL names