### PR TITLE
122-modal-updates: bold division text, extend title box

### DIFF
--- a/sde_indexing_helper/static/css/collection_detail.css
+++ b/sde_indexing_helper/static/css/collection_detail.css
@@ -211,6 +211,15 @@ color:black;
     border-radius: 4px;
     border: none;
     height: 29px;
+    width: 400px;
+   }
+
+   .button-wrapper {
+    justify-content: center;
+   }
+
+   .bold {
+    font-weight: 600;
    }
 
    .modal-header {

--- a/sde_indexing_helper/static/js/collection_detail.js
+++ b/sde_indexing_helper/static/js/collection_detail.js
@@ -137,8 +137,8 @@ $(document).ready(function () {
   $("body").on("change", "#detailDivisionDropdown", function () {
     $modal = $("#divisionChangeModal").modal();
     var selectedText = $("#detailDivisionDropdown option:selected").text();
-    $("#caption").text(
-      `Divison will be changed from ${currentDivisonText} to ${selectedText}.`
+    $("#caption").html(
+      `Divison will be changed from <span class="bold">${currentDivisonText}</span> to <span class="bold">${selectedText}</span>.`
     );
     collection_id = $(this).data("collection-id");
     newDivisionVal = $(this).val();

--- a/sde_indexing_helper/templates/sde_collections/collection_detail.html
+++ b/sde_indexing_helper/templates/sde_collections/collection_detail.html
@@ -336,10 +336,10 @@ aria-labelledby="titleChangeModal" aria-hidden="true">
                 <form id="titleChangeModalForm">
                         <input type="text" name="inputFieldName" id="inputFieldId" value="{{collection.name}}"> 
                         <div class="button-wrapper">
-                        <button type="submit" class="btn btn-secondary modal-button-1" id="cancelTitleRename">Cancel</button> 
-                        <button type="submit" class="btn btn-primary modal-button-2" data-dismiss="modal" id="renameTitle">Rename</button> 
-                    </div>
-                    </form>
+                            <button type="submit" class="btn btn-secondary modal-button-1" id="cancelTitleRename">Cancel</button> 
+                            <button type="submit" class="btn btn-primary modal-button-2" data-dismiss="modal" id="renameTitle">Rename</button> 
+                        </div>
+                </form>
             </div>
     </div>
 </div>


### PR DESCRIPTION
Closes https://github.com/orgs/NASA-IMPACT/projects/112/views/1?pane=issue&itemId=66264855

Bold the two division texts when changing divisions on details page. 
Title input box extended, buttons centered for title change.