### PR TITLE
123-comment-scroll

### DIFF
--- a/sde_indexing_helper/static/js/collection_detail.js
+++ b/sde_indexing_helper/static/js/collection_detail.js
@@ -59,8 +59,15 @@ function postDocTypeChange(collection_id, docType) {
 $(document).ready(function() {
   if (localStorage.getItem("WorkflowStatusChange")) {
     toastr.success("Workflow Status Updated!");
-    localStorage.removeItem("WorkflowStatusChange")
+    localStorage.removeItem("WorkflowStatusChange");
+  }
+})
 
+//Scroll position for comments
+$(document).ready(function() {
+  if (localStorage.getItem("commentScroll")) {
+    $(window).scrollTop(localStorage.getItem("commentScroll"));
+    localStorage.removeItem("commentScroll");
   }
 })
 
@@ -401,4 +408,7 @@ function handleWorkflowStatusSelect() {
 
 $(document).ready(function () {
   handleWorkflowStatusSelect();
+  $("button[name='comment_button']").click(function() {
+    localStorage.setItem("commentScroll", $(window).scrollTop());
+  })
 });


### PR DESCRIPTION
Closes https://github.com/orgs/NASA-IMPACT/projects/112/views/1?pane=issue&itemId=66264886

Saves position in local storage, reload on submit, restore page position and clears position in local storage

Does have a slight 'flash' on the reload on submit.