### PR TITLE
127-pagination-location

### DIFF
--- a/sde_indexing_helper/static/css/candidate_url_list.css
+++ b/sde_indexing_helper/static/css/candidate_url_list.css
@@ -446,3 +446,10 @@ div.dt-buttons .btn.processing:after {
    .dropdown-item:hover{
     background-color: #0066CA !important;
    }
+
+
+/* pagination position */
+div.dt-container div.dt-paging ul.pagination {
+    position: absolute;
+    right: 60px;
+}


### PR DESCRIPTION
https://github.com/NASA-IMPACT/sde-indexing-helper-frontend/issues/127

Set pagination to right side, done via css.

Look to come back and adjust datatables to use the `layout:` option instead of `dom` option.