### PR TITLE
143-details-workflow-change: bold collection and new status

### DIFF
--- a/sde_indexing_helper/static/js/collection_detail.js
+++ b/sde_indexing_helper/static/js/collection_detail.js
@@ -379,8 +379,8 @@ function handleWorkflowStatusSelect() {
     var workflow_status = $(this).attr("value");
     var new_workflow_status = $(this).text();
 
-    $(".workflow-status-change-caption").text(
-      `Workflow status for ${collectionName} will change to ${new_workflow_status}`
+    $(".workflow-status-change-caption").html(
+      `<div>Workflow status for <span class="bold">${collectionName}</span> will change to <span class="bold">${new_workflow_status}</span></div>`
     );
 
     $("#workflowStatusChangeModalForm").on("click", "button", function (event) {


### PR DESCRIPTION
Closes https://github.com/NASA-IMPACT/sde-indexing-helper-frontend/issues/143

Note: Kept text as it was originally, so it does not say changing from x to y as mentioned in the ticket, but it changes for (collection) to (new status).