### PR TITLE
Updated dockerignore and gitignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,13 @@
 .pre-commit-config.yaml
 .readthedocs.yml
 .travis.yml
-venv
 .git
+
+# ignore local python environments
+venv
+.venv
+
+# prevent large backup files from being copied into the image
 /backups
+*.sql
+*.gz

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@
 .travis.yml
 venv
 .git
+/backups

--- a/.gitignore
+++ b/.gitignore
@@ -292,9 +292,7 @@ config_generation/config.py
 # Model's inference files
 Document_Classifier_inference/model.pt
 
-# Database backup
-backup.json
+# Ignore Database Backup files
 /backups
-
-# Prod backup
-prod_backup-20240423.json
+*.sql
+*.gz

--- a/.gitignore
+++ b/.gitignore
@@ -294,6 +294,7 @@ Document_Classifier_inference/model.pt
 
 # Database backup
 backup.json
+/backups
 
 # Prod backup
 prod_backup-20240423.json


### PR DESCRIPTION
Added to not track the /backups folder that takes a considerable amount of space and results in the docker build failing.