### PR TITLE
1252 document type filter not working in delta urls page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,3 +137,8 @@ For each PR made, an entry should be added to this changelog. It should contain
   - Description: The feedback form API was throwing CORS errors and to rectify that, we need to add the apt https link for sde-lrm.
   - Changes:
     - Added `https://sde-lrm.nasa-impact.net` to `CORS_ALLOWED_ORIGINS` in the base settings.
+
+- 1252-document-type-filter-not-working-in-delta-urls-page
+  - Description: Fixed document type filtering functionality in the "Document Type Patterns" tab in Delta URLs page.
+  - Changes:
+    - Added a new event listener to the Document Type Patterns dropdown to trigger the filtering of the table results based on the selected value.

--- a/sde_indexing_helper/static/js/delta_url_list.js
+++ b/sde_indexing_helper/static/js/delta_url_list.js
@@ -881,6 +881,11 @@ function initializeDataTable() {
   $("#deltaDocTypeMatchPatternFilter").on("beforeinput", function (val) {
     document_type_patterns_table.columns(0).search(this.value).draw();
   });
+
+  $("#document-type-patterns-dropdown-2").on("change", function () {
+    document_type_patterns_table.columns(2).search(this.value).draw();
+  });
+
 }
 
 var division_patterns_table = $("#division_patterns_table").DataTable({


### PR DESCRIPTION
**Description:** Fixed document type filtering functionality in the "Document Type Patterns" tab in Delta URLs page.

Changes
- Added a new event listener to the Document Type Patterns dropdown to trigger the filtering of the table results based on the selected value.
