### PR TITLE
1251 column sorting issue curated urls count sorts by delta urls count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,5 +141,5 @@ For each PR made, an entry should be added to this changelog. It should contain
 - 1251-column-sorting-issue-curated-urls-count-sorts-by-delta-urls-count
   - Description: Fixed incorrect sorting behavior in Collections table where sorting by Curated URLs column was not working as expected.
   - Changes:
-    - Added `data-order` attribute to Delta URLs and Curated URLs table cells to enable proper numeric sorting
-    - Ensured raw numeric values are used for sorting while maintaining formatted display with anchor tags
+    - Added `data-order` attribute to URL count columns for proper numeric sorting
+    - Updated SearchPane comparisons to use `@data-order` values instead of string-based loose equality checks to ensure correct numeric filtering

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,3 +137,9 @@ For each PR made, an entry should be added to this changelog. It should contain
   - Description: The feedback form API was throwing CORS errors and to rectify that, we need to add the apt https link for sde-lrm.
   - Changes:
     - Added `https://sde-lrm.nasa-impact.net` to `CORS_ALLOWED_ORIGINS` in the base settings.
+
+- 1251-column-sorting-issue-curated-urls-count-sorts-by-delta-urls-count
+  - Description: Fixed incorrect sorting behavior in Collections table where sorting by Curated URLs column was not working as expected.
+  - Changes:
+    - Added `data-order` attribute to Delta URLs and Curated URLs table cells to enable proper numeric sorting
+    - Ensured raw numeric values are used for sorting while maintaining formatted display with anchor tags

--- a/sde_indexing_helper/static/js/collection_list.js
+++ b/sde_indexing_helper/static/js/collection_list.js
@@ -138,43 +138,47 @@ let table = $("#collection_table").DataTable({
           {
             label: "0 URLs",
             value: function (rowData, rowIdx) {
-              return $(rowData[COLUMNS.DELTA_URLS]).text() == 0;
+              return parseInt(rowData[COLUMNS.DELTA_URLS]['@data-order']) === 0;
             },
           },
           {
             label: "1 solo URL",
             value: function (rowData, rowIdx) {
-              return $(rowData[COLUMNS.DELTA_URLS]).text() == 1;
+              return parseInt(rowData[COLUMNS.DELTA_URLS]['@data-order']) === 1;
             },
           },
           {
             label: "1 to 100 URLs",
             value: function (rowData, rowIdx) {
-              return $(rowData[COLUMNS.DELTA_URLS]).text() <= 100 && $(rowData[COLUMNS.DELTA_URLS]).text() > 1;
+              const value = parseInt(rowData[COLUMNS.DELTA_URLS]['@data-order']);
+              return value > 1 && value <= 100;
             },
           },
           {
             label: "100 to 1,000 URLs",
             value: function (rowData, rowIdx) {
-              return $(rowData[COLUMNS.DELTA_URLS]).text() <= 1000 && $(rowData[COLUMNS.DELTA_URLS]).text() > 100;
+              const value = parseInt(rowData[COLUMNS.DELTA_URLS]['@data-order']);
+              return value > 100 && value <= 1000;
             },
           },
           {
             label: "1,000 to 10,000 URLs",
             value: function (rowData, rowIdx) {
-              return $(rowData[COLUMNS.DELTA_URLS]).text() <= 10000 && $(rowData[COLUMNS.DELTA_URLS]).text() > 1000;
+              const value = parseInt(rowData[COLUMNS.DELTA_URLS]['@data-order']);
+              return value > 1000 && value <= 10000;
             },
           },
           {
             label: "10,000 to 100,000 URLs",
             value: function (rowData, rowIdx) {
-              return $(rowData[COLUMNS.DELTA_URLS]).text() <= 100000 && $(rowData[COLUMNS.DELTA_URLS]).text() > 10000;
+              const value = parseInt(rowData[COLUMNS.DELTA_URLS]['@data-order']);
+              return value > 10000 && value <= 100000;
             },
           },
           {
             label: "Over 100,000 URLs",
             value: function (rowData, rowIdx) {
-              return $(rowData[COLUMNS.DELTA_URLS]).text() > 100000;
+              return parseInt(rowData[COLUMNS.DELTA_URLS]['@data-order']) > 100000;
             },
           },
         ],
@@ -189,43 +193,47 @@ let table = $("#collection_table").DataTable({
           {
             label: "0 URLs",
             value: function (rowData, rowIdx) {
-              return $(rowData[COLUMNS.CURATED_URLS]).text() == 0;
+              return parseInt(rowData[COLUMNS.CURATED_URLS]['@data-order']) === 0;
             },
           },
           {
             label: "1 solo URL",
             value: function (rowData, rowIdx) {
-              return $(rowData[COLUMNS.CURATED_URLS]).text() == 1;
+              return parseInt(rowData[COLUMNS.CURATED_URLS]['@data-order']) === 1;
             },
           },
           {
             label: "1 to 100 URLs",
             value: function (rowData, rowIdx) {
-              return $(rowData[COLUMNS.CURATED_URLS]).text() <= 100 && $(rowData[COLUMNS.CURATED_URLS]).text() > 1;
+              const value = parseInt(rowData[COLUMNS.CURATED_URLS]['@data-order']);
+              return value > 1 && value <= 100;
             },
           },
           {
             label: "100 to 1,000 URLs",
             value: function (rowData, rowIdx) {
-              return $(rowData[COLUMNS.CURATED_URLS]).text() <= 1000 && $(rowData[COLUMNS.CURATED_URLS]).text() > 100;
+              const value = parseInt(rowData[COLUMNS.CURATED_URLS]['@data-order']);
+              return value > 100 && value <= 1000;
             },
           },
           {
             label: "1,000 to 10,000 URLs",
             value: function (rowData, rowIdx) {
-              return $(rowData[COLUMNS.CURATED_URLS]).text() <= 10000 && $(rowData[COLUMNS.CURATED_URLS]).text() > 1000;
+              const value = parseInt(rowData[COLUMNS.CURATED_URLS]['@data-order']);
+              return value > 1000 && value <= 10000;
             },
           },
           {
             label: "10,000 to 100,000 URLs",
             value: function (rowData, rowIdx) {
-              return $(rowData[COLUMNS.CURATED_URLS]).text() <= 100000 && $(rowData[COLUMNS.CURATED_URLS]).text() > 10000;
+              const value = parseInt(rowData[COLUMNS.CURATED_URLS]['@data-order']);
+              return value > 10000 && value <= 100000;
             },
           },
           {
             label: "Over 100,000 URLs",
             value: function (rowData, rowIdx) {
-              return $(rowData[COLUMNS.CURATED_URLS]).text() > 100000;
+              return parseInt(rowData[COLUMNS.CURATED_URLS]['@data-order']) > 100000;
             },
           },
         ],

--- a/sde_indexing_helper/templates/sde_collections/collection_list.html
+++ b/sde_indexing_helper/templates/sde_collections/collection_list.html
@@ -151,14 +151,14 @@
                     <td class="whiteText noBorder">{{ collection.get_division_display }}</td>
 
                     <!-- Delta URLs Column - Shows count and links if >= 0 -->
-                    <td class="noBorder centerAlign">
+                    <td class="noBorder centerAlign" data-order="{{ collection.num_delta_urls }}">
                         <a href=" {% if collection.num_delta_urls >= 0 %} {% url 'sde_collections:delta_urls' collection.pk %} {% endif %} "
                            class="btn btn-sm {% if collection.num_delta_urls >= 0 %}btn-primary {% else %}disabled{% endif %}candidateCount"
                            role="button">{{ collection.num_delta_urls|intcomma }}</a>
                     </td>
 
                     <!-- Curated URLs Column - Shows count and links if >= 0 -->
-                    <td class="noBorder centerAlign">
+                    <td class="noBorder centerAlign" data-order="{{ collection.num_curated_urls }}">
                         <a href=" {% if collection.num_curated_urls >= 0 %} {% url 'sde_collections:delta_urls' collection.pk %} {% endif %} "
                            class="btn btn-sm {% if collection.num_curated_urls >= 0 %}btn-primary {% else %}disabled{% endif %}candidateCount"
                            role="button">{{ collection.num_curated_urls|intcomma }}</a>


### PR DESCRIPTION
**Description:** Fixed incorrect sorting behavior in Collections table where sorting by Curated URLs column was not working as expected.

Changes:
    - Added `data-order` attribute to URL count columns for proper numeric sorting
    - Updated SearchPane comparisons to use `@data-order` values instead of string-based loose equality checks to ensure correct numeric filtering
