### PR TITLE
ci: pin GitHub Actions to SHA digests (fix zizmor unpinned-uses)

### DIFF
--- a/.github/workflows/issue-formatter.yml
+++ b/.github/workflows/issue-formatter.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     - name: Add text to new blank issue
-      uses: actions/github-script@v6
+      uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |

--- a/.github/workflows/run_full_test_suite.yml
+++ b/.github/workflows/run_full_test_suite.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Check out merged code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Set up Docker Compose
         run: |


### PR DESCRIPTION
Pins all GitHub Actions workflow steps to full SHA digests, eliminating the `unpinned-uses` supply-chain risk identified by zizmor (3 findings fixed).

Closes #1323

### Recommended next steps

1. Dependabot is already configured for `github-actions` in this repo — pinned SHAs will be kept up-to-date automatically.
2. Add [zizmor-action](https://github.com/zizmorcore/zizmor-action?tab=readme-ov-file#usage-with-github-advanced-security-recommended) for continuous workflow security scanning in CI.

---
_Generated by [ds-security-scanning](https://github.com/developmentseed/ds-security-scanning) zizmor-cli-unpinned-uses_